### PR TITLE
Add downgrade_creationkit tag

### DIFF
--- a/tags.yaml
+++ b/tags.yaml
@@ -102,4 +102,5 @@ ck:
     text: https://raw.githubusercontent.com/wabbajack-tools/discord_bot_tags/main/tags/permanent/game/skyrim/ck.md
 curios:
     text: https://raw.githubusercontent.com/wabbajack-tools/discord_bot_tags/main/tags/permanent/game/skyrim/curios.md
-    
+downgrade_ck:
+    text: https://raw.githubusercontent.com/wabbajack-tools/discord_bot_tags/main/tags/temporary/game/skyrim/downgrade_creationkit.md

--- a/tags/temporary/game/skyrim/downgrade_creationkit.md
+++ b/tags/temporary/game/skyrim/downgrade_creationkit.md
@@ -1,0 +1,12 @@
+## How to downgrade Creation Kit v1.6.1130.0
+
+Run (Win+R) and paste (steam://open/console). This will open the Steam Console.
+In the Steam Console, run these commands one by one;
+`download_depot 1946180 1946182 926444740758492387`
+`download_depot 1946180 1946183 2725999750516785042`
+Open the listed directory as mentioned by the Steam Console.
+Default, it's listed as `C:\Program Files (x86)\Steam\steamapps\content\app_1946180`.
+Open the **depot_1946182** folder, copy and paste the `CreationKit` file into your Skyrim SE folder.
+Go back to the `app_1946180` folder, open **depot_1946183**, copy and paste all files into your Skyrim SE folder.
+When asked to overwrite existing files, click on **Yes**.
+Find Skyrim Special Edition: Creation Kit in your steam library, right click -> Properties ->  Updates -> Only update this game when I launch it.


### PR DESCRIPTION
Temporary tag until all Skyrim modlists are recompiled with the new 2.0 update (even though it is listed as version 1.6.1378.1...)