### PR TITLE
Add fix installationscript tag for FNV

### DIFF
--- a/tags.yaml
+++ b/tags.yaml
@@ -133,6 +133,8 @@ curios:
     text: https://raw.githubusercontent.com/wabbajack-tools/discord_bot_tags/main/tags/permanent/game/skyrim/curios.md
 downgrade_creationkit:
     text: https://raw.githubusercontent.com/wabbajack-tools/discord_bot_tags/main/tags/temporary/game/skyrim/downgrade_creationkit.md
+fix_fnv_installscript:
+    text: https://raw.githubusercontent.com/wabbajack-tools/discord_bot_tags/main/tags/permanent/game/falloutnewvegas/fix_fnv_installscript.md
 reyakendsanity:
   text: https://raw.githubusercontent.com/wabbajack-tools/discord_bot_tags/main/tags/permanent/game/skyrim/ReyakEndSanity.md
     

--- a/tags/permanent/game/falloutnewvegas/fix_fnv_installscript.md
+++ b/tags/permanent/game/falloutnewvegas/fix_fnv_installscript.md
@@ -1,0 +1,16 @@
+## Missing game file InstallScript.vdf
+
+If your manual helper file or log file shows references to 'InstallScript' file failed to download,
+i.e. `Missing game file InstallScript.vdf`
+
+Follow these steps:
+
+1. Navigate to your **Steam**'s **Fallout New Vegas** folder.
+2. Within the installation folder, look for `InstallScript.vdf` and open it with Notepad.
+3. Search for a line that says "run process" or "Run Process" (line 13).
+
+* If the line is written as "run process", rewrite it to "Run Process" (capitalized).
+
+* If the line is written as "Run Process", rewrite it to "run process" (lowercase).
+
+Close Wabbajack, if you haven't already, and try installing the modlist again.


### PR DESCRIPTION
Apparently necessary for some Fallout New Vegas modlists, like Wasteland Prospects.