### PR TITLE
add the tag no_access.md

### DIFF
--- a/tags.yaml
+++ b/tags.yaml
@@ -21,6 +21,8 @@ pineapple_on_pizza:
     text: https://raw.githubusercontent.com/wabbajack-tools/discord_bot_tags/main/tags/permanent/general/pineapple_on_pizza.md
 pizza_no_pineapple:
     text: https://raw.githubusercontent.com/wabbajack-tools/discord_bot_tags/main/tags/permanent/general/pizza_no_pineapple.md
+no_access:
+    text: https://raw.githubusercontent.com/wabbajack-tools/discord_bot_tags/main/tags/permanent/general/no_access.md
 #Wabbajack Commands
 api:
     text: https://raw.githubusercontent.com/wabbajack-tools/discord_bot_tags/main/tags/permanent/general/API.md

--- a/tags/permanent/general/no_access.md
+++ b/tags/permanent/general/no_access.md
@@ -1,0 +1,5 @@
+## 🔒 No Access
+
+If you're directed to a channel that appears as `🔒 No Access` it means you likely don't have the required role to view it.
+
+For public channels, you can assign yourself the necessary role in the <id:customize> section.


### PR DESCRIPTION
add tag no access with contents

If you're directed to a channel that appears as `🔒 No Access` it means you likely don't have the required role to view it.

For public channels, you can assign yourself the necessary role in the <id:customize> section.