### PR TITLE
Add guidance for handling broken download links

### DIFF
--- a/tags/permanent/general/broken.md
+++ b/tags/permanent/general/broken.md
@@ -1,6 +1,6 @@
-# Broken or Fail download links
+# Broken download links
 
-Wabbajack staff **cannot** provide you mirrors for broken downloads.
+Wabbajack staff **cannot** provide you mirrors for broken download links.
 
 You will need to either go to the appropriate support discord for the list you are trying to install and find assistance there or consult their Nexus page, forum or wherever you downloaded the list from for assistance.
 


### PR DESCRIPTION
Updated the heading and clarified the message regarding broken download links.